### PR TITLE
Remove Link beta details from sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # Link
 
-| :exclamation:  This payment method is limited to US based Stripe Accounts accepting USD. It's still in beta, please email link-beta@stripe.com to request access.   |
-|-------------------------------------------------------------------------------------------------------------|
-
 Watch the [video](https://youtu.be/-ufvKuYAtSg) to learn more.
 
 This sample shows how to integrate Link which allows your customers
@@ -101,7 +98,14 @@ A: We chose the most minimal framework to convey the key Stripe calls and concep
 
 ## Get support
 
-For questions about Link, please reach out to link-beta@stripe.com for support.
+If you found a bug or want to suggest a new [feature/use case/sample], please [file an issue](../../issues).
+
+If you have questions, comments, or need help with code, we're here to help:
+- on [Discord](https://stripe.com/go/developer-chat)
+- on Twitter at [@StripeDev](https://twitter.com/StripeDev)
+- on Stack Overflow at the [stripe-payments](https://stackoverflow.com/tags/stripe-payments/info) tag
+
+Sign up to [stay updated with developer news](https://go.stripe.global/dev-digest).
 
 ## Author(s)
 

--- a/client/html/index.js
+++ b/client/html/index.js
@@ -53,7 +53,7 @@ document.addEventListener('DOMContentLoaded', async (e) => {
 
 
   // Create and mount the Shipping Address Element
-  const shippingAddressElement = elements.create("shippingAddress", { allowedCountries: ['US'] });
+  const shippingAddressElement = elements.create("address", { mode: 'shipping', allowedCountries: ['US'] });
   shippingAddressElement.mount("#shipping-address-element");
 
   // If you need access to the shipping address entered

--- a/client/html/index.js
+++ b/client/html/index.js
@@ -1,9 +1,7 @@
 document.addEventListener('DOMContentLoaded', async (e) => {
   const { publishableKey } = await fetch("/config").then(res => res.json());
 
-  const stripe = Stripe(publishableKey, {
-    betas: ['shipping_address_element_beta_1']
-  });
+  const stripe = Stripe(publishableKey);
 
   const { clientSecret } = await fetch("/create-payment-intent", {
     method: "POST",

--- a/client/html/success.js
+++ b/client/html/success.js
@@ -1,10 +1,7 @@
 document.addEventListener('DOMContentLoaded', async (e) => {
   // Initialize Stripe.js with your publishable key.
   const {publishableKey} = await fetch("/config").then(res => res.json());
-  const stripe = Stripe(publishableKey, {
-    betas: ['link_beta_3'],
-    apiVersion: "2020-08-27;link_beta=v1"
-  });
+  const stripe = Stripe(publishableKey);
 
   // Get the PaymentIntent clientSecret from query string params.
   const params = new URLSearchParams(window.location.search);

--- a/client/react-cra/src/App.js
+++ b/client/react-cra/src/App.js
@@ -11,10 +11,7 @@ function App() {
   useEffect(() => {
     fetch("/config").then(async (r) => {
       const { publishableKey } = await r.json();
-      setStripePromise(loadStripe(publishableKey, {
-        betas: ['link_beta_3'],
-        apiVersion: "2019-05-16;link_beta=v1"
-      }));
+      setStripePromise(loadStripe(publishableKey));
     });
   }, []);
 

--- a/client/react-cra/src/Checkout.js
+++ b/client/react-cra/src/Checkout.js
@@ -4,7 +4,7 @@ import {
   Elements,
   LinkAuthenticationElement,
   PaymentElement,
-  ShippingAddressElement,
+  AddressElement,
   useStripe,
   useElements,
 } from "@stripe/react-stripe-js";
@@ -49,8 +49,8 @@ const PaymentForm = () => {
           />
 
           <h3>Shipping address</h3>
-          <ShippingAddressElement
-            options={{allowedCountries: ['US']}}
+          <AddressElement
+            options={{mode: 'shipping', allowedCountries: ['US']}}
 
             // Access the address like so:
             // onChange={(event) => {

--- a/client/react-cra/src/PaymentSuccess.js
+++ b/client/react-cra/src/PaymentSuccess.js
@@ -1,13 +1,8 @@
 import {useState, useEffect} from 'react';
 import { useSearchParams } from "react-router-dom";
-import {loadStripe} from "@stripe/stripe-js";
 import {
   Elements,
-  LinkAuthenticationElement,
-  PaymentElement,
-  ShippingAddressElement,
   useStripe,
-  useElements,
 } from "@stripe/react-stripe-js";
 
 const PaymentSuccess = () => {

--- a/server/README.md
+++ b/server/README.md
@@ -12,7 +12,7 @@ instructions in the directory on how to run.
 * [PHP (Slim)](php/README.md)
 
 
-Coming soon (post beta):
+Coming soon:
 * [Java (Spark)](java/README.md)
 * [Go](go/README.md)
 * [.NET](dotnet/README.md)

--- a/server/php/public/index.php
+++ b/server/php/public/index.php
@@ -77,10 +77,7 @@ try {
     </div>
     <script>
       document.addEventListener('DOMContentLoaded', async (e) => {
-        const stripe = Stripe('<?= $_ENV["STRIPE_PUBLISHABLE_KEY"] ?>', {
-          betas: ['link_beta_2'],
-          apiVersion: "2020-08-27;link_beta=v1"
-        });
+        const stripe = Stripe('<?= $_ENV["STRIPE_PUBLISHABLE_KEY"] ?>');
 
         const clientSecret = '<?= $paymentIntent->client_secret ?>';
         addMessage(`Client secret: ${clientSecret}`);


### PR DESCRIPTION
r? @cjavilla-stripe 

- Updates to the GA'd AddressElement
- Removes Link beta flags
- Removes references to active beta 

Screenshots of clients, tested with html and react
<img width="461" alt="Screenshot 2023-02-13 at 4 00 27 PM" src="https://user-images.githubusercontent.com/49654207/218602207-069cd810-ed41-4841-ac96-ce9fc0657a4d.png">
<img width="523" alt="Screenshot 2023-02-13 at 3 56 28 PM" src="https://user-images.githubusercontent.com/49654207/218602216-316bd80b-9563-4a30-8959-39d6daaa4874.png">
