### PR TITLE
Add reminders about security best practices and redact secrets in logs

### DIFF
--- a/server/java/src/main/java/com/stripe/sample/Server.java
+++ b/server/java/src/main/java/com/stripe/sample/Server.java
@@ -26,6 +26,11 @@ public class Server {
     private static final Gson GSON = new Gson();
 
     // Environment variable constants
+    // Don't put any keys in code. Use an environment variable (as shown
+    // here) or secrets vault to supply keys to your integration.
+    //
+    // See https://docs.stripe.com/keys-best-practices and find your
+    // keys at https://dashboard.stripe.com/apikeys.
     private static final String STRIPE_SECRET_KEY = "STRIPE_SECRET_KEY";
     private static final String STRIPE_PUBLISHABLE_KEY = "STRIPE_PUBLISHABLE_KEY";
     private static final String STRIPE_WEBHOOK_SECRET = "STRIPE_WEBHOOK_SECRET";

--- a/server/nextjs/lib/stripe.ts
+++ b/server/nextjs/lib/stripe.ts
@@ -1,5 +1,10 @@
 import Stripe from "stripe";
 
+// Don't put any keys in code. Use an environment variable (as shown
+// here) or secrets vault to supply keys to your integration.
+//
+// See https://docs.stripe.com/keys-best-practices and find your
+// keys at https://dashboard.stripe.com/apikeys.
 export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
   apiVersion: "2025-12-15.clover",
   appInfo: {

--- a/server/node/server.js
+++ b/server/node/server.js
@@ -4,6 +4,11 @@ const { resolve } = require('path');
 // Replace if using a different env file or config
 const env = require('dotenv').config({ path: '../../.env' });
 
+// Don't put any keys in code. Use an environment variable (as shown
+// here) or secrets vault to supply keys to your integration.
+//
+// See https://docs.stripe.com/keys-best-practices and find your
+// keys at https://dashboard.stripe.com/apikeys.
 const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY, {
   appInfo: { // For sample support and debugging, not required for production:
     name: "stripe-samples/link-with-stripe",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -107,6 +107,11 @@ end
 
 SERVER_URL = ENV.fetch('SERVER_URL', 'http://localhost:4242')
 Dotenv.load
+# Don't put any keys in code. Use an environment variable (as shown
+# here) or secrets vault to supply keys to your integration.
+#
+# See https://docs.stripe.com/keys-best-practices and find your
+# keys at https://dashboard.stripe.com/apikeys.
 Stripe.api_key = ENV['STRIPE_SECRET_KEY']
 Stripe.max_network_retries = 2
 Stripe.api_version = "2020-08-27"


### PR DESCRIPTION
## Summary

- Adds comments before `STRIPE_SECRET_KEY` assignments in all server files urging users not to put keys in code and pointing to [https://docs.stripe.com/keys-best-practices](https://docs.stripe.com/keys-best-practices).
